### PR TITLE
GitHub用Issueテンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+### Summary
+
+
+
+### Steps to reproduce:
+
+1. Step 1
+2. ...
+
+### What is the current bug behavior?
+
+
+
+### 内容
+
+
+
+### 実行環境
+
+
+### バグを再現できるログやスクリーンショット
+
+
+
+### 修正方法(修正案)
+
+
+


### PR DESCRIPTION
このプロジェクトは、GitHubでホストされています。

しかし、GitLab用のIssue templateがありました。GitLab用のテンプレートの内容を、GitHub用のテンプレートに追加しました。