### PR TITLE
Index page: MetaNoteアイコンのborderを削除

### DIFF
--- a/objects/script/default.php
+++ b/objects/script/default.php
@@ -69,7 +69,9 @@
         </noscript>
 
         <div class="container p-main_container">
-          <div class="row p-img_wrapper"><img class="card p-img_card" src="/icon/home.png" class="p-main_image"></div>
+          <div class="row p-img_wrapper">
+            <img class="card p-img_card border-0 p-main_image" src="/icon/home.png">
+          </div>
           <div class="row">
             <div class="col p-buttons_container d-flex justify-content-center">
               <?php if (defined("USER_LOGGEDIN")) { ?>


### PR DESCRIPTION
インデックスページにて、余分だと考えられるMetaNoteアイコンのborderを削除しました。

かつ、MetaNoteアイコンの`<img>`で、class属性が二つ使われているhtml構文エラーを修正しました。

### before
![IMG_0761](https://user-images.githubusercontent.com/79000684/234833748-a27d8ff2-4b2c-4a23-9de0-cf209713d135.jpeg)
### after
![IMG_0760](https://user-images.githubusercontent.com/79000684/234833517-8fce2d60-3b79-4db7-8c64-b0220a016691.jpeg)
