### PR TITLE
Markdown Viewerの自動更新(パフォーマンスの最適化済み)

### DIFF
--- a/objects/script/edit.php
+++ b/objects/script/edit.php
@@ -132,11 +132,12 @@
     <script>
       let beforeMarkdownData = "";
       function updateMarkdownViewer(){
-        if(_('naka').value !== beforeMarkdownData){
-          beforeMarkdownData = _('naka').value;
+        const nakaValue = document.getElementById("naka").value;
+        if(nakaValue !== beforeMarkdownData){
+          beforeMarkdownData = nakaValue;
           marknew();
         }
-        setTimeout(updateMarkdownViewer);
+        setTimeout(updateMarkdownViewer,100);
       }
     </script>
   </body>

--- a/objects/script/edit.php
+++ b/objects/script/edit.php
@@ -129,6 +129,16 @@
       </div>
     </form>
     <script>$(function(){$(".lined").linedtextarea();});</script>
+    <script>
+      let beforeMarkdownData = "";
+      function updateMarkdownViewer(){
+        if(_('naka').value !== beforeMarkdownData){
+          beforeMarkdownData = _('naka').value;
+          marknew();
+        }
+        setTimeout(updateMarkdownViewer);
+      }
+    </script>
   </body>
 </html>
 


### PR DESCRIPTION
Markdowb viewerを自動更新するようにしました。
### 変更点
Markdown viewerの自動更新について、昨日、パフォーマンスの観点で、すぐ更新はやめておくという話をいただきました。
それを解決して、リアルタイム更新を可能にしました

#6 では、`input`イベントを使って更新していました。しかし、今回は、`setTimeout`をつかい、100msごとに、更新しています。
### パフォーマンスについて
次のコードでMarked.jsの速度を計測してみました。
Marked.jsに渡すMarkdownは、10万文字です。
```js
// 計測回数
const n = 100;
// 使う文字たち
const strings = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789# -\n";
// ランダムなテキストの生成
const text = [...new Array(100000)].map(()=>strings[Math.floor(strings.length*Math.random())]).join("");

const start = new Date();

for(let i = 0; i !== n; i++){
  DOMPurify.sanitize(marked.parse(text));
}

const end = new Date();

const time = end.getTime() - start.getTime();

console.log(`${n / (time/1000)} 論文 /s`);
```
さまざまな端末で計測して、一番低いスコアが出たのは、Xperia ace iiで、約32論文/sでした。
- http://sotsuron.net/moji/
- https://digmee.jp/article/310368
- https://www.enago.jp/academy/too-long-paper/

このようなサイトから、10万文字の論文は、多い方だと言えます。

このPull requestでは、100msに一回、更新します。marked.jsの32論文/sでも、余裕をもって更新できます

よって、パフォーマンスの問題はないと考えられます。