### PR TITLE
<code>タグのスタイルの変更

### DIFF
--- a/objects/script/view.php
+++ b/objects/script/view.php
@@ -143,7 +143,12 @@
       });
     });
     </script>
-
+    <style>
+      code{
+        background-color: #333;
+        color: #fff;
+      }
+    </style>
   </head>
   <body>
     <?=Get_Body_Header()?>


### PR DESCRIPTION
Markdown形式の論文について、`<code>`タグのスタイルを変更しました。
````markdown
```js
console.log(0)
```
````
のような、Markdownや、
```markdown
`MetaNote`
```
のようなMarkdownで、コードを示したときに、区別しやすくなりました。

codeタグの背景色を`#333`に、文字色を`#fff`にしました。